### PR TITLE
Updated text

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
           <div class="mdl-cell mdl-cell--6-col">
             <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
               <input class="mdl-textfield__input" type="text" id="tables" name="tables">
-              <label class="mdl-textfield__label" for="tables">Tables(Comma-separated)</label>
+              <label class="mdl-textfield__label" for="tables">Tables(Comma-separated without spaces)</label>
             </div>
           </div>
           <div class="mdl-cell mdl-cell--6-col">


### PR DESCRIPTION
When i entered the tables names, i automatically entering space after the comma but it doesn't work properly with the space, so i would be nice if it reminds the user that he should not use space. Better option would be to trim when splitting the commas.